### PR TITLE
Fix refreshing bug in admin page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { Text, HBox, Spacer } from './elem';
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import { Collapse } from '@material-ui/core';
-import { Button } from '@mui/material';
+import { Button, LinearProgress  } from '@mui/material';
 
 import { MsgButton, NotificationMessage } from './types';
 import UserEvents from './user-events';
@@ -97,7 +97,9 @@ function App(props: any) {
       <BrowserRouter>
         <Routes>
           <Route path="/admin" element={
-            !synced ? null:
+            // ---- Loading bar ----
+            !synced ? <LinearProgress /> 
+                    :
             // ---- Login -----
             !user ? <Login
               onLogin={(u:User) => {}}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ function App(props: any) {
   const [msg, setMsg] = useState<NotificationMessage | undefined>(undefined);
   const [connected, setConnected] = useState(false);
   const [windowSize, setWindowSize] = useState({ w: window.innerWidth, h: window.innerHeight });
+  const [synced, setSynced] = useState(false);
 
 
   useEffect(() => {
@@ -49,7 +50,9 @@ function App(props: any) {
     clear: () => {
       setMsg(undefined);
     },
-    inProgress: () => setMsg({ progress: true, open: true }),
+    inProgress: () => {
+      setMsg({ progress: true, open: true })
+    },
   }
 
   useEffect(() => {
@@ -58,6 +61,7 @@ function App(props: any) {
       (user) => {
         console.log("user:", JSON.stringify(user));
         setUser(user?.email);
+        setSynced(true);
       });
     if (success) {
       setConnected(true);
@@ -93,6 +97,7 @@ function App(props: any) {
       <BrowserRouter>
         <Routes>
           <Route path="/admin" element={
+            !synced ? null:
             // ---- Login -----
             !user ? <Login
               onLogin={(u:User) => {}}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { Text, HBox, Spacer } from './elem';
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import { Collapse } from '@material-ui/core';
-import { Button, LinearProgress  } from '@mui/material';
+import { Button, LinearProgress } from '@mui/material';
 
 import { MsgButton, NotificationMessage } from './types';
 import UserEvents from './user-events';


### PR DESCRIPTION
when refrashing admin page, login screen shows for some seconds.

This is because _user_ variable need to be refetch from server.
until it been fetch - the logic in App "thinks" the user does not login.

To fix it I add new variable - _synced_ - to save that we connect to server and got response from it about the user.
Until it synced - line progress bar will show in top of the screen